### PR TITLE
update Debian version -- Python 3.12 isn't available buster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim-buster
+FROM python:3.12-slim-bookworm
 
 ADD . /app
 WORKDIR /app


### PR DESCRIPTION
- Python 3.12 container isn't available with Buster, so upgrade to Bookworm